### PR TITLE
-iis heartbeat and launching iis by site name

### DIFF
--- a/Centaur.nuspec
+++ b/Centaur.nuspec
@@ -6,7 +6,7 @@
 
     <id>Centaur</id>
 
-    <version>1.0.7</version>
+    <version>1.0.8</version>
 
     <title>Centaur</title>
 

--- a/src/Centaur.ExampleWebApp/StatusHandler.cs
+++ b/src/Centaur.ExampleWebApp/StatusHandler.cs
@@ -8,7 +8,7 @@ namespace Centaur.ExampleWebApp
 {
     public class StatusHandler : IHttpHandler
     {
-        private static readonly List<DateTime> WarmUps = new List<DateTime>();
+        internal static readonly List<DateTime> WarmUps = new List<DateTime>();
 
         public void ProcessRequest(HttpContext context)
         {

--- a/src/Centaur.ExampleWebApp/Web.config
+++ b/src/Centaur.ExampleWebApp/Web.config
@@ -10,6 +10,10 @@
            verb="GET"
            path="/"
            type="Centaur.ExampleWebApp.ExampleHandler, Centaur.ExampleWebApp, Version=1.0.0.0, Culture=neutral" />
+      <add name="ExampleHandler2"
+           verb="GET"
+           path="/example"
+           type="Centaur.ExampleWebApp.ExampleHandler, Centaur.ExampleWebApp, Version=1.0.0.0, Culture=neutral" />
       <add name="StatusHandler"
            verb="GET"
            path="/status"

--- a/src/Centaur.Tests/Centaur.Tests.csproj
+++ b/src/Centaur.Tests/Centaur.Tests.csproj
@@ -46,6 +46,8 @@
   <ItemGroup>
     <Compile Include="ExampleWebAppConfigFileTest.cs" />
     <Compile Include="ExampleWebAppTest.cs" />
+    <Compile Include="Helpers.cs" />
+    <Compile Include="IisConfigInitTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StatusCheckTest.cs" />
   </ItemGroup>

--- a/src/Centaur.Tests/ExampleWebAppConfigFileTest.cs
+++ b/src/Centaur.Tests/ExampleWebAppConfigFileTest.cs
@@ -10,14 +10,11 @@ namespace Centaur.Tests
     {
         private IISExpressHost _host;
         private string _configFilePath;
-        private string _webAppPath;
 
         [SetUp]
         public void StartHost()
         {
-             _configFilePath = Path.GetFullPath(TestContext.CurrentContext.TestDirectory + "/applicationhost.config");
-              _webAppPath = Path.GetFullPath(TestContext.CurrentContext.TestDirectory + "../../../../Centaur.ExampleWebApp/");
-            configurePhysicalPath(_configFilePath, _webAppPath);
+            _configFilePath = Helpers.ConfigurePath(TestContext.CurrentContext.TestDirectory);
 
             _host = new IISExpressHost(new IISExpressConfig(_configFilePath));
             _host.Start();
@@ -27,36 +24,13 @@ namespace Centaur.Tests
         public void StopHost()
         {
             _host.Stop();
-            configurePhysicalPath(_configFilePath, "(none)");
-        }
-
-        private void configurePhysicalPath(string configFilePath, string applicationPath)
-        {
-            using (var serverManager = new ServerManager(configFilePath))
-            {
-                serverManager.Sites[0].Applications[0].VirtualDirectories[0].PhysicalPath = applicationPath;
-                serverManager.CommitChanges();
-            }
+            Helpers.CleanConfig(_configFilePath);
         }
 
         [Test]
         public void IisExpressHostedWebAppRespondsToRequests()
         {
-            Assert.That(Get("http://localhost:9060"), Is.EqualTo("hello!"));
-        }
-
-        static string Get(string url)
-        {
-            var request = WebRequest.Create(url);
-            using (var response = request.GetResponse())
-            {
-                using (var responseStream = response.GetResponseStream())
-                {
-                    if (responseStream == null) return null;
-                    var reader = new StreamReader(responseStream);
-                    return reader.ReadToEnd();
-                }
-            }
+            Assert.That(Helpers.Get("http://localhost:9060"), Is.EqualTo("hello!"));
         }
     }
 }

--- a/src/Centaur.Tests/ExampleWebAppTest.cs
+++ b/src/Centaur.Tests/ExampleWebAppTest.cs
@@ -25,21 +25,7 @@ namespace Centaur.Tests
         [Test]
         public void IisExpressHostedWebAppRespondsToRequests()
         {
-            Assert.That(Get("http://localhost:9059"), Is.EqualTo("hello!"));
-        }
-
-        static string Get(string url)
-        {
-            var request = WebRequest.Create(url);
-            using (var response = request.GetResponse())
-            {
-                using (var responseStream = response.GetResponseStream())
-                {
-                    if (responseStream == null) return null;
-                    var reader = new StreamReader(responseStream);
-                    return reader.ReadToEnd();
-                }
-            }
+            Assert.That(Helpers.Get("http://localhost:9059"), Is.EqualTo("hello!"));
         }
     }
 }

--- a/src/Centaur.Tests/Helpers.cs
+++ b/src/Centaur.Tests/Helpers.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.Web.Administration;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Centaur.Tests
+{
+    internal class Helpers
+    {
+        internal static string ConfigurePath(string directory)
+        {
+            var configFilePath = Path.GetFullPath(directory + "/applicationhost.config");
+            var webAppPath = Path.GetFullPath(directory + "../../../../Centaur.ExampleWebApp/");
+            configurePhysicalPath(configFilePath, webAppPath);
+
+            return configFilePath;
+        }
+
+        internal static void CleanConfig(string config)
+        {
+            configurePhysicalPath(config, "(none)");
+        }
+        internal static void configurePhysicalPath(string configFilePath, string applicationPath)
+        {
+            using (var serverManager = new ServerManager(configFilePath))
+            {
+                serverManager.Sites[0].Applications[0].VirtualDirectories[0].PhysicalPath = applicationPath;
+                serverManager.CommitChanges();
+            }
+        }
+
+        internal static string Get(string url)
+        {
+            var request = WebRequest.Create(url);
+            using (var response = request.GetResponse())
+            {
+                using (var responseStream = response.GetResponseStream())
+                {
+                    if (responseStream == null) return null;
+                    var reader = new StreamReader(responseStream);
+                    return reader.ReadToEnd();
+                }
+            }
+        }
+
+    }
+}

--- a/src/Centaur.Tests/IisConfigInitTests.cs
+++ b/src/Centaur.Tests/IisConfigInitTests.cs
@@ -1,0 +1,41 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Centaur.Tests
+{
+    [TestFixture]
+    public class IisConfigInitTests
+    {
+        private IISExpressHost _host;
+        private string _configFilePath;
+
+        [SetUp]
+        public void Setup()
+        {
+            IISExpressProcess.ClearAll();
+        }
+
+        [TearDown]
+        public void StopHost()
+        {
+            _host?.Stop();
+            Helpers.CleanConfig(_configFilePath);
+        }
+
+        [Test]
+        public void TestThatIisCanStartSiteUsingTheName()
+        {
+            _configFilePath = Helpers.ConfigurePath(TestContext.CurrentContext.TestDirectory);
+
+            var config = new IISExpressConfig(_configFilePath, "Centaur Example Web App");
+            _host = new IISExpressHost(config);
+            _host.Start();
+
+            Assert.That(Helpers.Get("http://localhost:9060"), Is.EqualTo("hello!"));
+        }
+    }
+}

--- a/src/Centaur/IISExpressConfig.cs
+++ b/src/Centaur/IISExpressConfig.cs
@@ -3,10 +3,16 @@ namespace Centaur
     public class IISExpressConfig
     {
         public string Path { get; private set; }
+        public string Site { get; private set; }
 
         public IISExpressConfig(string path)
         {
             Path = path;
+        }
+        public IISExpressConfig(string path, string site)
+        {
+            Path = path;
+            Site = site;
         }
     }
 }

--- a/src/Centaur/IISExpressHost.cs
+++ b/src/Centaur/IISExpressHost.cs
@@ -46,9 +46,11 @@ namespace Centaur
         public bool LogOutput { get; set; }
 
         public string StatusCheckPath { get; set; }
-        public TimeSpan StatusCheckInterval { get; set; }
-        public int StatusCheckAttempts { get; set; }
+        public TimeSpan StatusCheckInterval { get; set; } = TimeSpan.FromMilliseconds(500);
+        public int StatusCheckAttempts { get; set; } = 0;
+        public bool IsNotFoundValid { get; set; } = false;
         public bool TraceErrors { get; set; }
+        public bool SystemTray { get; set; } = false;
 
         public void Dispose()
         {
@@ -82,6 +84,7 @@ namespace Centaur
 
         public void Stop()
         {
+            if (_process == null) return;
             _process.StandardInput.Write("Q");
             KillProcessAndChildren(_process.Id);
         }
@@ -110,12 +113,14 @@ namespace Centaur
             if (Config != null)
             {
                 var configPath = Path.GetFullPath(Config.Path);
-                args = String.Format("/config:\"{0}\" /systray:false", configPath);
+                args = string.IsNullOrEmpty(Config.Site) ? 
+                    String.Format("/config:\"{0}\" /systray:{1}", configPath, SystemTray.ToString().ToLower())
+                    : String.Format("/config:\"{0}\" /site:\"{1}\" /systray:{2} ", configPath, Config.Site, SystemTray.ToString().ToLower());
             }
             else
             {
                 var path = Path.GetFullPath(WebSitePath);
-                args = String.Format("/path:{0} /port:{1} /systray:false", path, Port);
+                args = String.Format("/path:{0} /port:{1} /systray:{2}", path, Port, SystemTray.ToString().ToLower());
             }
 
             if (TraceErrors)
@@ -181,14 +186,26 @@ namespace Centaur
             _process.BeginOutputReadLine();
         }
 
+        public bool IsAlive()
+        {
+            try
+            {
+                PerformStatusCheck();
+                return true;
+            }
+            catch { return false; }
+        }
+
         private bool TryStatusCheck(string url)
         {
             try
             {
-                new WebClient().DownloadString(url);
+                WebRequest r = WebRequest.Create(url);
+                var resp = r.GetResponse();
             }
-            catch (WebException)
+            catch (WebException e)
             {
+                if (e.Message.Contains("404") && IsNotFoundValid) return true;
                 Thread.Sleep(StatusCheckInterval);
                 return false;
             }

--- a/src/Centaur/Properties/AssemblyInfo.cs
+++ b/src/Centaur/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.7.0")]
-[assembly: AssemblyFileVersion("1.0.7.0")]
+[assembly: AssemblyVersion("1.0.8.0")]
+[assembly: AssemblyFileVersion("1.0.8.0")]


### PR DESCRIPTION
-can add a site to the iisexpressconfig by name (for situations where you have multiple sites in a project)
-added ability to toggle system tray (for debugging tests)
-added a heartbeat function to check if the server is alive
-status check now checks through a response and determines if 404s are a valid response (for testing webservices that don't deliver a payload on the home page)
