### PR TITLE
Add ability to inject environment variables into IIS Express process

### DIFF
--- a/src/Centaur.ExampleWebApp/Centaur.ExampleWebApp.csproj
+++ b/src/Centaur.ExampleWebApp/Centaur.ExampleWebApp.csproj
@@ -51,6 +51,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ExampleHandler.cs" />
+    <Compile Include="EnvironmentVariableHandler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StatusHandler.cs" />
   </ItemGroup>

--- a/src/Centaur.ExampleWebApp/EnvironmentVariableHandler.cs
+++ b/src/Centaur.ExampleWebApp/EnvironmentVariableHandler.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Web;
+
+namespace Centaur.ExampleWebApp
+{
+    public class EnvironmentVariableHandler : IHttpHandler
+    {
+        public void ProcessRequest(HttpContext context)
+        {
+            context.Response.Write(Environment.GetEnvironmentVariable("PAYLOAD"));
+            context.Response.End();
+        }
+
+        public bool IsReusable { get { return true; } }
+    }
+}

--- a/src/Centaur.ExampleWebApp/Web.config
+++ b/src/Centaur.ExampleWebApp/Web.config
@@ -14,6 +14,10 @@
            verb="GET"
            path="/status"
            type="Centaur.ExampleWebApp.StatusHandler, Centaur.ExampleWebApp, Version=1.0.0.0, Culture=neutral" />
+      <add name="EnvironmentVariableHandler"
+           verb="GET"
+           path="/envvar"
+           type="Centaur.ExampleWebApp.EnvironmentVariableHandler, Centaur.ExampleWebApp, Version=1.0.0.0, Culture=neutral" />
     </handlers>
     
   </system.webServer>

--- a/src/Centaur.Tests/Centaur.Tests.csproj
+++ b/src/Centaur.Tests/Centaur.Tests.csproj
@@ -45,6 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ExampleWebAppConfigFileTest.cs" />
+    <Compile Include="EnvironmentVariablesTest.cs" />
     <Compile Include="ExampleWebAppTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StatusCheckTest.cs" />

--- a/src/Centaur.Tests/EnvironmentVariablesTest.cs
+++ b/src/Centaur.Tests/EnvironmentVariablesTest.cs
@@ -1,0 +1,46 @@
+﻿using System.IO;
+using System.Net;
+using NUnit.Framework;
+
+namespace Centaur.Tests
+{
+    [TestFixture]
+    public class EnvironmentVariablesTest
+    {
+        private IISExpressHost _host;
+
+        [SetUp]
+        public void StartHost()
+        {
+            _host = new IISExpressHost(TestContext.CurrentContext.TestDirectory + "../../../../Centaur.ExampleWebApp/", 9059);
+            _host.EnvironmentVariables.Add("PAYLOAD", "injected");
+            _host.Start();
+        }
+
+        [TearDown]
+        public void StopHost()
+        {
+            _host.Stop();
+        }
+
+        [Test]
+        public void IisExpressHostedWebAppCanHaveInjectedEnvironmentVariables()
+        {
+            Assert.That(Get("http://localhost:9059/envvar"), Is.EqualTo("injected"));
+        }
+
+        static string Get(string url)
+        {
+            var request = WebRequest.Create(url);
+            using (var response = request.GetResponse())
+            {
+                using (var responseStream = response.GetResponseStream())
+                {
+                    if (responseStream == null) return null;
+                    var reader = new StreamReader(responseStream);
+                    return reader.ReadToEnd();
+                }
+            }
+        }
+    }
+}

--- a/src/Centaur/IISExpressHost.cs
+++ b/src/Centaur/IISExpressHost.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -49,6 +50,8 @@ namespace Centaur
         public TimeSpan StatusCheckInterval { get; set; }
         public int StatusCheckAttempts { get; set; }
         public bool TraceErrors { get; set; }
+
+        public Dictionary<string, string> EnvironmentVariables { get; set; } = new Dictionary<string, string>();
 
         public void Dispose()
         {
@@ -141,7 +144,7 @@ namespace Centaur
         private void StartProcess(string iisExpressPath, string args)
         {
             if (LogOutput) Console.WriteLine(iisExpressPath + " " + args);
-            _process.StartInfo = new ProcessStartInfo(iisExpressPath, args)
+            var startInfo = new ProcessStartInfo(iisExpressPath, args)
             {
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
@@ -150,6 +153,13 @@ namespace Centaur
                 WindowStyle = ProcessWindowStyle.Hidden,
                 CreateNoWindow = true
             };
+
+            foreach (var variable in EnvironmentVariables)
+            {
+                startInfo.EnvironmentVariables.Add(variable.Key, variable.Value);
+            }
+
+            _process.StartInfo = startInfo;
 
             _process.EnableRaisingEvents = true;
             if (LogOutput)


### PR DESCRIPTION
It can helpful to be able to set env vars to modify the SUT during test execution.

`_host.EnvironmentVariables.Add("PAYLOAD", "injected");`